### PR TITLE
Unify loop body types by changing N_WHILE_STATEMENT

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -1777,7 +1777,7 @@ module.exports = {
             components: {name: 'value', what: (/,()/), captureIndex: 1}
         },
         'N_WHILE_STATEMENT': {
-            components: ['T_WHILE', (/\(/), {name: 'condition', what: 'N_EXPRESSION'}, (/\)/), (/\{/), {name: 'statements', zeroOrMoreOf: 'N_STATEMENT'}, (/\}/)]
+            components: ['T_WHILE', (/\(/), {name: 'condition', what: 'N_EXPRESSION'}, (/\)/), {name: 'body', what: 'N_STATEMENT'}]
         }
     },
     start: 'N_PROGRAM'

--- a/test/integration/statements/whileTest.js
+++ b/test/integration/statements/whileTest.js
@@ -31,7 +31,10 @@ describe('PHP Parser grammar while statement integration', function () {
                         name: 'N_BOOLEAN',
                         bool: 'true'
                     },
-                    statements: []
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: []
+                    }
                 }]
             }
         },
@@ -45,13 +48,16 @@ describe('PHP Parser grammar while statement integration', function () {
                         name: 'N_BOOLEAN',
                         bool: 'true'
                     },
-                    statements: [{
-                        name: 'N_ECHO_STATEMENT',
-                        expressions: [{
-                            name: 'N_INTEGER',
-                            number: '4'
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: [{
+                            name: 'N_ECHO_STATEMENT',
+                            expressions: [{
+                                name: 'N_INTEGER',
+                                number: '4'
+                            }]
                         }]
-                    }]
+                    }
                 }]
             }
         },
@@ -79,7 +85,10 @@ describe('PHP Parser grammar while statement integration', function () {
                             }
                         }]
                     },
-                    statements: []
+                    body: {
+                        name: 'N_COMPOUND_STATEMENT',
+                        statements: []
+                    }
                 }]
             }
         }


### PR DESCRIPTION
This brings while loop AST nodes in line with the other loop constructs. Required as part of changes to fix issues with the `goto` operator.