### PR TITLE
Parse PHP `clone ...` expressions as N_CLONE_EXPRESSION

### DIFF
--- a/src/grammar.js
+++ b/src/grammar.js
@@ -660,10 +660,13 @@ module.exports = {
             components: ['T_DO', {name: 'body', what: 'N_STATEMENT'}, 'T_WHILE', (/\(/), {name: 'condition', what: 'N_EXPRESSION'}, (/\)/), 'N_END_STATEMENT']
         },
         'N_EXPRESSION_LEVEL_1_B': {
-            captureAs: 'N_UNARY_EXPRESSION',
-            components: [{name: 'operator', optionally: 'T_CLONE'}, {name: 'operand', what: 'N_EXPRESSION_LEVEL_1_A'}],
-            ifNoMatch: {component: 'operator', capture: 'operand'},
-            options: {prefix: true}
+            captureAs: 'N_CLONE_EXPRESSION',
+            components: {
+                oneOf: [
+                    ['T_CLONE', {name: 'operand', what: 'N_EXPRESSION_LEVEL_1_A'}],
+                    'N_EXPRESSION_LEVEL_1_A'
+                ]
+            }
         },
         'N_EMPTY_ARRAY_INDEX': {
             captureAs: 'N_ARRAY_INDEX',

--- a/test/integration/operators/cloneTest.js
+++ b/test/integration/operators/cloneTest.js
@@ -1,0 +1,78 @@
+/*
+ * PHP-To-AST - PHP parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://uniter.github.com/phptoast/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptoast/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    expect = require('chai').expect,
+    tools = require('../../tools');
+
+describe('PHP Parser grammar clone operator integration', function () {
+    var parser;
+
+    beforeEach(function () {
+        parser = tools.createParser();
+    });
+
+    _.each({
+        'returning a clone of a variable': {
+            code: 'return clone $sourceVar;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_CLONE_EXPRESSION',
+                        operand: {
+                            name: 'N_VARIABLE',
+                            variable: 'sourceVar'
+                        }
+                    }
+                }]
+            }
+        },
+        'assigning a clone of a variable to another variable': {
+            code: '$targetVar = clone $sourceVar;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_EXPRESSION',
+                        left: {
+                            name: 'N_VARIABLE',
+                            variable: 'targetVar'
+                        },
+                        right: [{
+                            operator: '=',
+                            operand: {
+                                name: 'N_CLONE_EXPRESSION',
+                                operand: {
+                                    name: 'N_VARIABLE',
+                                    variable: 'sourceVar'
+                                }
+                            }
+                        }]
+                    }
+                }]
+            }
+        }
+    }, function (scenario, description) {
+        describe(description, function () {
+            var code = '<?php ' + scenario.code;
+
+            // Pretty-print the code strings so any non-printable characters are readable
+            describe('when the code is ' + JSON.stringify(code) + ' ?>', function () {
+                it('should return the expected AST', function () {
+                    expect(parser.parse(code)).to.deep.equal(scenario.expectedAST);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Clone expressions were previously parsed as `N_UNARY_EXPRESSION`s,
but support for this was never added to PHPToJS and clone expressions
are slightly different from other logical/arithmetical operators
so it seems to make sense to give them a specific node type.