### PR TITLE
Parsing improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -373,22 +373,22 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -579,9 +579,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-date-object": {
@@ -618,12 +618,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-symbol": {
@@ -717,9 +717,9 @@
       "dev": true
     },
     "microdash": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.0.tgz",
-      "integrity": "sha512-NzJ6hCeuFOaXe7RUc1SpSjwEHvUxmEIGsiRn5Nx8Dv3Pk3+fLVe51W3ASSAkVoebPloXZWEGUoUk/05NVbVCMw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.1.tgz",
+      "integrity": "sha512-NJz1FkkTucluPbIzxkuLutzFTI3WWGJ8iOBAJIO49oHK19YkAOR/q8/XASiYS8J8OK8zGpxSD6/j/+M90gqdsQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -746,9 +746,9 @@
       }
     },
     "mocha": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -875,9 +875,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -1087,28 +1087,6 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
       }
     },
     "string.prototype.trimstart": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,9 +328,9 @@
           "dev": true
         },
         "entities": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
-          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
+          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
           "dev": true
         }
       }
@@ -373,9 +373,9 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -454,9 +454,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -493,9 +493,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -658,9 +658,9 @@
       }
     },
     "jshint": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.0.tgz",
-      "integrity": "sha512-ooaD/hrBPhu35xXW4gn+o3SOuzht73gdBuffgJzrZBJZPGgGiiTvJEgTyxFvBO2nz0+X1G6etF8SzUODTlLY6Q==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.1.tgz",
+      "integrity": "sha512-WXWePB8ssAH3DlD05IoqolsY6arhbll/1+i2JkRPpihQAuiNaR/gSt8VKIcxpV5m6XChP0hCwESQUqpuQMA8Tg==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
@@ -717,9 +717,9 @@
       "dev": true
     },
     "microdash": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.3.0.tgz",
-      "integrity": "sha1-TQ0yKY1UllS9lIhGAzkzqBwdkjs="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/microdash/-/microdash-1.4.0.tgz",
+      "integrity": "sha512-NzJ6hCeuFOaXe7RUc1SpSjwEHvUxmEIGsiRn5Nx8Dv3Pk3+fLVe51W3ASSAkVoebPloXZWEGUoUk/05NVbVCMw=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -737,18 +737,18 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
+      "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -764,7 +764,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
+        "mkdirp": "0.5.5",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -918,9 +918,9 @@
       }
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -942,11 +942,11 @@
       "dev": true
     },
     "parsing": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.0.0.tgz",
-      "integrity": "sha512-kGbuWxnoJhyrq5PJK59i9Gb1VfN1+n/3j1vQSXGviPdZsAbNGsJi4/VX5wbg4wtsensdNeGZmTqz8h03zSXvfA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/parsing/-/parsing-2.1.0.tgz",
+      "integrity": "sha512-hSV37eE9NZnid7Kc5S01aoXH6Cg8TpATVrsXBZ9PdpY96lrb6iFsxm5axtLrhQKp0e1FxiKH6PNi8YWjahPm7Q==",
       "requires": {
-        "microdash": "^1.0.0"
+        "microdash": "^1.4.0"
       }
     },
     "path-exists": {
@@ -986,9 +986,9 @@
       }
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
       "dev": true
     },
     "readable-stream": {
@@ -1079,24 +1079,46 @@
         "strip-ansi": "^4.0.0"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -328,9 +328,9 @@
           "dev": true
         },
         "entities": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-          "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw==",
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
           "dev": true
         }
       }
@@ -658,19 +658,27 @@
       }
     },
     "jshint": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.11.1.tgz",
-      "integrity": "sha512-WXWePB8ssAH3DlD05IoqolsY6arhbll/1+i2JkRPpihQAuiNaR/gSt8VKIcxpV5m6XChP0hCwESQUqpuQMA8Tg==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.12.0.tgz",
+      "integrity": "sha512-TwuuaUDmra0JMkuqvqy+WGo2xGHSNjv1BA1nTIgtH2K5z1jHuAEeAgp7laaR+hLRmajRjcrM71+vByBDanCyYA==",
       "dev": true,
       "requires": {
         "cli": "~1.0.0",
         "console-browserify": "1.1.x",
         "exit": "0.1.x",
         "htmlparser2": "3.8.x",
-        "lodash": "~4.17.11",
+        "lodash": "~4.17.19",
         "minimatch": "~3.0.2",
         "shelljs": "0.3.x",
         "strip-json-comments": "1.0.x"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.19",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "dev": true
+        }
       }
     },
     "just-extend": {
@@ -690,9 +698,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.get": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "jshint": "^2.11.1",
+    "jshint": "^2.12.0",
     "mocha": "^7.2.0",
     "nowdoc": "^1.0.1",
     "sinon": "^5.1.1"

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "test": "npm run jshint && npm run mocha"
   },
   "dependencies": {
-    "microdash": "^1.4.0",
+    "microdash": "^1.4.1",
     "parsing": "^2.1.0",
     "phpcommon": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "jshint": "^2.11.1",
-    "mocha": "^7.1.2",
+    "mocha": "^7.2.0",
     "nowdoc": "^1.0.1",
     "sinon": "^5.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "test": "npm run jshint && npm run mocha"
   },
   "dependencies": {
-    "microdash": "~1",
-    "parsing": "^2.0.0",
+    "microdash": "^1.4.0",
+    "parsing": "^2.1.0",
     "phpcommon": "^2.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "jshint": "^2.11.0",
-    "mocha": "^7.1.1",
+    "jshint": "^2.11.1",
+    "mocha": "^7.1.2",
     "nowdoc": "^1.0.1",
     "sinon": "^5.1.1"
   },

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -448,7 +448,19 @@ module.exports = {
             components: [(/\{/), {name: 'statements', zeroOrMoreOf: 'N_STATEMENT'}, (/\}/)]
         },
         'N_CONSTANT_DEFINITION': {
-            components: ['T_CONST', {name: 'constant', what: 'T_STRING'}, (/=/), {name: 'value', rule: 'N_EXPRESSION'}, 'N_END_STATEMENT']
+            components: [
+                'T_CONST',
+                {
+                    name: 'constants',
+                    oneOrMoreOf: [
+                        {name: 'constant', rule: 'T_STRING'},
+                        (/=/),
+                        {name: 'value', rule: 'N_EXPRESSION'},
+                        (/,|(?=;|[?%]>\n?)/)
+                    ]
+                },
+                'N_END_STATEMENT'
+            ]
         },
         'N_CONSTANT_STATEMENT': {
             components: [

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -1550,10 +1550,6 @@ module.exports = {
                 (/\}/)
             ]
         },
-        'N_STRING_SIMPLE_VARIABLE_VARIABLE': {
-            captureAs: 'N_VARIABLE_EXPRESSION',
-            components: {name: 'expression', what: [(/\$\{(?=\$)/), 'N_VARIABLE', (/\}/)]}
-        },
         'N_STRING_SIMPLE_INTERPOLATED_BRACED_BARE_VARIABLE': {
             // Don't swallow whitespace - it should remain inside the captured plain text parts of the string
             components: [{name: 'variable', what: 'T_STRING'}, (/(?!\s*::)/)]

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -653,29 +653,16 @@ module.exports = {
             ifNoMatch: {component: 'operator', capture: 'operand'},
             options: {prefix: true}
         },
-        'N_EXPRESSION_LEVEL_2_A': {
-            captureAs: 'N_CLASS_CONSTANT',
-            components: {oneOf: [
-                [
-                    {name: 'className', oneOf: ['N_NAMESPACED_REFERENCE', 'N_EXPRESSION_LEVEL_1_B']},
-                    'T_DOUBLE_COLON',
-                    {name: 'constant', what: ['T_STRING', (/(?!\()/)]}
-                ],
-                {name: 'next', what: 'N_EXPRESSION_LEVEL_1_B'}
-            ]},
-            ifNoMatch: {component: 'constant', capture: 'next'}
-        },
-        'N_CLASS_CONSTANT': 'N_EXPRESSION_LEVEL_2_A',
         'N_EMPTY_ARRAY_INDEX': {
             captureAs: 'N_ARRAY_INDEX',
             components: {name: 'indices', what: [(/\[/), (/\]/)]},
             options: {indices: true}
         },
-        'N_EXPRESSION_LEVEL_2_B': {
+        'N_EXPRESSION_LEVEL_2_A': {
             components: [
                 {
                     name: 'expression',
-                    oneOf: ['N_EXPRESSION_LEVEL_2_A', 'N_NAMESPACED_REFERENCE']
+                    oneOf: ['N_EXPRESSION_LEVEL_1_B', 'N_NAMESPACED_REFERENCE']
                 },
                 {
                     name: 'member',
@@ -745,6 +732,14 @@ module.exports = {
                                     {name: 'property', what: 'N_STATIC_MEMBER'}
                                 ]
                             },
+                            // Class constant
+                            {
+                                name: 'class_constant',
+                                what: [
+                                    'T_DOUBLE_COLON',
+                                    {name: 'constant', what: ['T_STRING', (/(?!\()/)]}
+                                ]
+                            },
                             // Call to callable stored in array index or static property
                             {
                                 name: 'callable',
@@ -799,6 +794,12 @@ module.exports = {
                             className: result,
                             property: member.static_property.property
                         };
+                    } else if (member.class_constant) {
+                        result = {
+                            name: 'N_CLASS_CONSTANT',
+                            className: result,
+                            constant: member.class_constant.constant
+                        };
                     } else if (member.callable) {
                         result = {
                             name: 'N_FUNCTION_CALL',
@@ -816,10 +817,10 @@ module.exports = {
             }
         },
         'N_EXPRESSION_LEVEL_2_C': {
-            components: {oneOf: ['N_REFERENCE', 'N_EXPRESSION_LEVEL_2_B']}
+            components: {oneOf: ['N_REFERENCE', 'N_EXPRESSION_LEVEL_2_A']}
         },
         'N_REFERENCE': {
-            components: [(/&/), {name: 'operand', what: 'N_EXPRESSION_LEVEL_2_B'}]
+            components: [(/&/), {name: 'operand', what: 'N_EXPRESSION_LEVEL_2_A'}]
         },
         'N_EXPRESSION_LEVEL_3_A': {
             oneOf: ['N_UNARY_PREFIX_EXPRESSION', 'N_UNARY_SUFFIX_EXPRESSION', 'N_EXPRESSION_LEVEL_2_C']
@@ -1052,7 +1053,7 @@ module.exports = {
         'N_EXPRESSION_LEVEL_21': {
             components: 'N_EXPRESSION_LEVEL_20'
         },
-        'N_LEFT_HAND_SIDE_EXPRESSION': 'N_EXPRESSION_LEVEL_2_B',
+        'N_LEFT_HAND_SIDE_EXPRESSION': 'N_EXPRESSION_LEVEL_2_A',
         'N_EXPRESSION_STATEMENT': {
             components: [{name: 'expression', what: 'N_EXPRESSION'}, 'N_END_STATEMENT']
         },

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -660,10 +660,13 @@ module.exports = {
             components: ['T_DO', {name: 'body', what: 'N_STATEMENT'}, 'T_WHILE', (/\(/), {name: 'condition', what: 'N_EXPRESSION'}, (/\)/), 'N_END_STATEMENT']
         },
         'N_EXPRESSION_LEVEL_1_B': {
-            captureAs: 'N_UNARY_EXPRESSION',
-            components: [{name: 'operator', optionally: 'T_CLONE'}, {name: 'operand', what: 'N_EXPRESSION_LEVEL_1_A'}],
-            ifNoMatch: {component: 'operator', capture: 'operand'},
-            options: {prefix: true}
+            captureAs: 'N_CLONE_EXPRESSION',
+            components: {
+                oneOf: [
+                    ['T_CLONE', {name: 'operand', what: 'N_EXPRESSION_LEVEL_1_A'}],
+                    'N_EXPRESSION_LEVEL_1_A'
+                ]
+            }
         },
         'N_EMPTY_ARRAY_INDEX': {
             captureAs: 'N_ARRAY_INDEX',

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -1091,7 +1091,7 @@ module.exports = {
             components: ['T_GOTO', {name: 'label', what: 'N_STRING'}, 'N_END_STATEMENT']
         },
         'N_HEREDOC': {
-            components: [{name: 'string', what: /<<<("?)([a-z0-9_]+)\1\r?\n([\s\S]*?)\r?\n\2(?=;?(?:\r?\n|$))/i, captureIndex: 3}],
+            components: [{name: 'string', what: /<<<\s*("?)([a-z0-9_]+)\1\r?\n([\s\S]*?)\r?\n\2(?=;?(?:\r?\n|$))/i, captureIndex: 3}],
             processor: function (node, parse) {
                 var innerMatch,
                     parts;
@@ -1284,7 +1284,7 @@ module.exports = {
             components: {name: 'string', what: 'N_NAMESPACE'}
         },
         'N_NOWDOC': {
-            components: [{name: 'string', what: /<<<'([a-z0-9_]+)'\r?\n([\s\S]*?)\r?\n\1(?=;?(?:\r?\n|$))/i, captureIndex: 2}]
+            components: [{name: 'string', what: /<<<\s*'([a-z0-9_]+)'\r?\n([\s\S]*?)\r?\n\1(?=;?(?:\r?\n|$))/i, captureIndex: 2}]
         },
         'N_NULL': {
             allowMerge: false,

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -1521,7 +1521,7 @@ module.exports = {
             captureAs: 'N_STRING_LITERAL',
             components: {
                 name: 'string',
-                what: (/(?:[^\\"${]|\\[\s\S]|\$(?=\$)|\$[^{a-zA-Z]|{\\\$|{[^$])+/),
+                what: (/(?:[^\\"${]|\\[\s\S]|\$(?=\$)|\$(?![{a-zA-Z])|{\\\$|{(?!\$))+/),
                 replace: stringEscapeReplacements
             }
         },

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -1531,7 +1531,7 @@ module.exports = {
             captureAs: 'N_VARIABLE_EXPRESSION',
             components: [
                 (/\${/),
-                'N_STRING_SIMPLE_INTERPOLATED_DEREFERENCE',
+                {rule: 'N_STRING_SIMPLE_INTERPOLATED_DEREFERENCE', ignoreWhitespace: true},
                 (/\}/)
             ]
         },
@@ -1595,7 +1595,7 @@ module.exports = {
                                 name: 'static_method_call',
                                 what: [
                                     'T_DOUBLE_COLON',
-                                    {name: 'method', oneOf: ['N_STRING', 'N_VARIABLE', 'N_VARIABLE_EXPRESSION']},
+                                    {name: 'method', oneOf: ['N_STRING', 'N_VARIABLE', 'N_VARIABLE_EXPRESSION', 'N_MEMBER_EXPRESSION']},
                                     (/\(/),
                                     {name: 'args', zeroOrMoreOf: ['N_EXPRESSION', {what: (/(,|(?=\)))()/), captureIndex: 2}]},
                                     (/\)/)

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -718,7 +718,7 @@ module.exports = {
                                 name: 'static_method_call',
                                 what: [
                                     'T_DOUBLE_COLON',
-                                    {name: 'method', oneOf: ['N_STRING', 'N_VARIABLE', 'N_VARIABLE_EXPRESSION']},
+                                    {name: 'method', oneOf: ['N_STRING', 'N_VARIABLE', 'N_VARIABLE_EXPRESSION', 'N_MEMBER_EXPRESSION']},
                                     (/\(/),
                                     {name: 'args', zeroOrMoreOf: ['N_EXPRESSION', {what: (/(,|(?=\)))()/), captureIndex: 2}]},
                                     (/\)/)
@@ -1809,6 +1809,9 @@ module.exports = {
                     {name: 'variable', what: (/\$\{([a-z0-9_]+)\}/i), captureIndex: 1}
                 ]}
             ]
+        },
+        'N_MEMBER_EXPRESSION': {
+            components: [(/\{/), 'N_EXPRESSION', (/\}/)]
         },
         'N_VARIABLE_EXPRESSION': {
             components: {

--- a/src/grammar.js
+++ b/src/grammar.js
@@ -953,7 +953,25 @@ module.exports = {
         },
         'N_EXPRESSION_LEVEL_11': {
             captureAs: 'N_EXPRESSION',
-            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_10'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/&&/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_10']}]}],
+            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_10'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/&(?!&)/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_10']}]}],
+            ifNoMatch: {component: 'right', capture: 'left'}
+            // TODO: Use buildBinaryExpression ahead of deprecating N_EXPRESSION for N_BINARY_EXPRESSION w/a single right operand
+        },
+        'N_EXPRESSION_LEVEL_12': {
+            captureAs: 'N_EXPRESSION',
+            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_11'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/\^/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_11']}]}],
+            ifNoMatch: {component: 'right', capture: 'left'}
+            // TODO: Use buildBinaryExpression ahead of deprecating N_EXPRESSION for N_BINARY_EXPRESSION w/a single right operand
+        },
+        'N_EXPRESSION_LEVEL_13': {
+            captureAs: 'N_EXPRESSION',
+            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_12'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/\|(?!\|)/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_12']}]}],
+            ifNoMatch: {component: 'right', capture: 'left'}
+            // TODO: Use buildBinaryExpression ahead of deprecating N_EXPRESSION for N_BINARY_EXPRESSION w/a single right operand
+        },
+        'N_EXPRESSION_LEVEL_14': {
+            captureAs: 'N_EXPRESSION',
+            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_13'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/&&/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_13']}]}],
             processor: function (node) {
                 if (!node.right) {
                     return node.left;
@@ -961,21 +979,6 @@ module.exports = {
 
                 return buildBinaryExpression(node.left, node.right);
             }
-        },
-        'N_EXPRESSION_LEVEL_12': {
-            captureAs: 'N_EXPRESSION',
-            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_11'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/\^/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_11']}]}],
-            ifNoMatch: {component: 'right', capture: 'left'}
-        },
-        'N_EXPRESSION_LEVEL_13': {
-            captureAs: 'N_EXPRESSION',
-            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_12'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/\|/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_12']}]}],
-            ifNoMatch: {component: 'right', capture: 'left'}
-        },
-        'N_EXPRESSION_LEVEL_14': {
-            captureAs: 'N_EXPRESSION',
-            components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_13'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: (/&/)}, {name: 'operand', oneOf: ['N_ASSIGNMENT_EXPRESSION', 'N_EXPRESSION_LEVEL_13']}]}],
-            ifNoMatch: {component: 'right', capture: 'left'}
         },
         'N_EXPRESSION_LEVEL_15': {
             captureAs: 'N_EXPRESSION',
@@ -1054,16 +1057,19 @@ module.exports = {
             captureAs: 'N_EXPRESSION',
             components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_17_B'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: 'T_LOGICAL_AND', replace: lowercaseReplacements}, {name: 'operand', what: 'N_EXPRESSION_LEVEL_17_B'}]}],
             ifNoMatch: {component: 'right', capture: 'left'}
+            // TODO: Use buildBinaryExpression ahead of deprecating N_EXPRESSION for N_BINARY_EXPRESSION w/a single right operand
         },
         'N_EXPRESSION_LEVEL_19': {
             captureAs: 'N_EXPRESSION',
             components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_18'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: 'T_LOGICAL_XOR', replace: lowercaseReplacements}, {name: 'operand', what: 'N_EXPRESSION_LEVEL_18'}]}],
             ifNoMatch: {component: 'right', capture: 'left'}
+            // TODO: Use buildBinaryExpression ahead of deprecating N_EXPRESSION for N_BINARY_EXPRESSION w/a single right operand
         },
         'N_EXPRESSION_LEVEL_20': {
             captureAs: 'N_EXPRESSION',
             components: [{name: 'left', what: 'N_EXPRESSION_LEVEL_19'}, {name: 'right', zeroOrMoreOf: [{name: 'operator', what: 'T_LOGICAL_OR', replace: lowercaseReplacements}, {name: 'operand', what: 'N_EXPRESSION_LEVEL_19'}]}],
             ifNoMatch: {component: 'right', capture: 'left'}
+            // TODO: Use buildBinaryExpression ahead of deprecating N_EXPRESSION for N_BINARY_EXPRESSION w/a single right operand
         },
         'N_EXPRESSION_LEVEL_21': {
             components: 'N_EXPRESSION_LEVEL_20'

--- a/test/integration/constructs/heredocTest.js
+++ b/test/integration/constructs/heredocTest.js
@@ -69,6 +69,22 @@ describe('PHP Parser grammar heredoc construct integration', function () {
                 }]
             }
         },
+        'quoted heredoc with whitespace before identifier containing only an interpolated variable': {
+            code: '<?php return <<< "EOS"\n$myValue\nEOS;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_HEREDOC',
+                        parts: [{
+                            name: 'N_VARIABLE',
+                            variable: 'myValue'
+                        }]
+                    }
+                }]
+            }
+        },
         'quoted heredoc containing an escaped variable': {
             code: '<?php return <<<"EOS"\nthis is not \\$a variable\nEOS;',
             expectedAST: {
@@ -87,6 +103,25 @@ describe('PHP Parser grammar heredoc construct integration', function () {
         },
         'unquoted heredoc containing some text followed by an interpolated variable': {
             code: '<?php return <<<EOS\nabc$myValue\nEOS;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_HEREDOC',
+                        parts: [{
+                            name: 'N_STRING_LITERAL',
+                            string: 'abc'
+                        }, {
+                            name: 'N_VARIABLE',
+                            variable: 'myValue'
+                        }]
+                    }
+                }]
+            }
+        },
+        'unquoted heredoc with whitespace before identifier containing some text followed by an interpolated variable': {
+            code: '<?php return <<< EOS\nabc$myValue\nEOS;',
             expectedAST: {
                 name: 'N_PROGRAM',
                 statements: [{

--- a/test/integration/constructs/nowdocTest.js
+++ b/test/integration/constructs/nowdocTest.js
@@ -34,6 +34,32 @@ describe('PHP Parser grammar nowdoc construct integration', function () {
                 }]
             }
         },
+        'nowdoc containing plain text': {
+            code: '<?php return <<<\'EOS\'\nMy text goes here!\nEOS;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_NOWDOC',
+                        string: 'My text goes here!'
+                    }
+                }]
+            }
+        },
+        'nowdoc containing plain text with whitespace before identifier': {
+            code: '<?php return <<< \'EOS\'\nMy text goes here!\nEOS;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_NOWDOC',
+                        string: 'My text goes here!'
+                    }
+                }]
+            }
+        },
         'nowdoc containing unescaped quotes': {
             code: '<?php return <<<\'EOS\'\ndouble-quote: " and single quote: \'\nEOS;',
             expectedAST: {

--- a/test/integration/constructs/stringInterpolationTest.js
+++ b/test/integration/constructs/stringInterpolationTest.js
@@ -97,6 +97,28 @@ describe('PHP Parser grammar string interpolation construct integration', functi
                 }]
             }
         },
+        'simple syntax: string interpolation with ${...} (dollar before braces) with leading whitespace': {
+            code: '<?php return "before${ value}after";',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_STRING_EXPRESSION',
+                        parts: [{
+                            name: 'N_STRING_LITERAL',
+                            string: 'before'
+                        }, {
+                            name: 'N_VARIABLE',
+                            variable: 'value'
+                        }, {
+                            name: 'N_STRING_LITERAL',
+                            string: 'after'
+                        }]
+                    }
+                }]
+            }
+        },
         'simple syntax: string interpolation with ${...} (dollar before braces) array dereference': {
             code: '<?php return "before ${myArray[21]} after";',
             expectedAST: {
@@ -249,6 +271,49 @@ describe('PHP Parser grammar string interpolation construct integration', functi
                                 method: {
                                     name: 'N_STRING',
                                     string: 'myStaticMethod'
+                                },
+                                args: []
+                            }
+                        }, {
+                            name: 'N_STRING_LITERAL',
+                            string: 'after'
+                        }]
+                    }
+                }]
+            }
+        },
+        'simple syntax: string interpolation with ${...} (dollar before braces) variable-variable dynamic static method call dereference': {
+            code: '<?php return "before${MyClass::{\'my\' . \'StaticMethod\'}()}after";',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_STRING_EXPRESSION',
+                        parts: [{
+                            name: 'N_STRING_LITERAL',
+                            string: 'before'
+                        }, {
+                            name: 'N_VARIABLE_EXPRESSION',
+                            expression: {
+                                name: 'N_STATIC_METHOD_CALL',
+                                className: {
+                                    name: 'N_STRING',
+                                    string: 'MyClass'
+                                },
+                                method: {
+                                    name: 'N_EXPRESSION',
+                                    left: {
+                                        name: 'N_STRING_LITERAL',
+                                        string: 'my'
+                                    },
+                                    right: [{
+                                        operator: '.',
+                                        operand: {
+                                            name: 'N_STRING_LITERAL',
+                                            string: 'StaticMethod'
+                                        }
+                                    }]
                                 },
                                 args: []
                             }

--- a/test/integration/expressions/staticMethodCallTest.js
+++ b/test/integration/expressions/staticMethodCallTest.js
@@ -83,87 +83,32 @@ describe('PHP Parser grammar static method call expression integration', functio
                     }
                 }]
             }
-        }/*,
-        'call to callable': {
-            code: '$myCallable();',
-            expectedAST: {
-                name: 'N_PROGRAM',
-                statements: [{
-                    name: 'N_EXPRESSION_STATEMENT',
-                    expression: {
-                        name: 'N_FUNCTION_CALL',
-                        func: {
-                            name: 'N_VARIABLE',
-                            variable: 'myCallable'
-                        },
-                        args: []
-                    }
-                }]
-            }
         },
-        'function call as term in expression with arguments including an expression': {
-            code: '$a = doSomething(1, 4 + 2, "test");',
+        'return of static method call of callable result': {
+            code: 'return $myCallable()::myStaticMethod();',
             expectedAST: {
                 name: 'N_PROGRAM',
                 statements: [{
-                    name: 'N_EXPRESSION_STATEMENT',
+                    name: 'N_RETURN_STATEMENT',
                     expression: {
-                        name: 'N_EXPRESSION',
-                        left: {
-                            name: 'N_VARIABLE',
-                            variable: 'a'
+                        name: 'N_STATIC_METHOD_CALL',
+                        className: {
+                            name: 'N_FUNCTION_CALL',
+                            func: {
+                                name: 'N_VARIABLE',
+                                variable: 'myCallable'
+                            },
+                            args: []
                         },
-                        right: [{
-                            operator: '=',
-                            operand: {
-                                name: 'N_FUNCTION_CALL',
-                                func: {
-                                    name: 'N_STRING',
-                                    string: 'doSomething'
-                                },
-                                args: [{
-                                    name: 'N_INTEGER',
-                                    number: '1'
-                                }, {
-                                    name: 'N_EXPRESSION',
-                                    left: {
-                                        name: 'N_INTEGER',
-                                        number: '4'
-                                    },
-                                    right: [{
-                                        operator: '+',
-                                        operand: {
-                                            name: 'N_INTEGER',
-                                            number: '2'
-                                        }
-                                    }]
-                                }, {
-                                    name: 'N_STRING_LITERAL',
-                                    string: 'test'
-                                }]
-                            }
-                        }]
-                    }
-                }]
-            }
-        },
-        'calling function in global namespace with prefixed path': {
-            code: '\\now();',
-            expectedAST: {
-                name: 'N_PROGRAM',
-                statements: [{
-                    name: 'N_EXPRESSION_STATEMENT',
-                    expression: {
-                        name: 'N_FUNCTION_CALL',
-                        func: {
+                        method: {
                             name: 'N_STRING',
-                            string: '\\now'
+                            string: 'myStaticMethod'
                         },
                         args: []
                     }
                 }]
             }
-        }*/
+        }
     }, function (scenario, description) {
         describe(description, function () {
             var code = '<?php ' + scenario.code;

--- a/test/integration/expressions/stringLiteralTest.js
+++ b/test/integration/expressions/stringLiteralTest.js
@@ -290,6 +290,40 @@ EOS
                     }
                 }]
             }
+        },
+        'double-quoted string containing a trailing dollar, potentially confused with interpolated variable': {
+            code: nowdoc(function () {/*<<<EOS
+<?php
+return "my string $";
+EOS
+*/;}), //jshint ignore:line
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_STRING_LITERAL',
+                        string: 'my string $'
+                    }
+                }]
+            }
+        },
+        'double-quoted string containing a trailing opening brace, potentially confused with complex interpolation syntax': {
+            code: nowdoc(function () {/*<<<EOS
+<?php
+return "my string {";
+EOS
+*/;}), //jshint ignore:line
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_STRING_LITERAL',
+                        string: 'my string {'
+                    }
+                }]
+            }
         }
     }, function (scenario, description) {
         describe(description, function () {

--- a/test/integration/operators/cloneTest.js
+++ b/test/integration/operators/cloneTest.js
@@ -1,0 +1,78 @@
+/*
+ * PHP-To-AST - PHP parser
+ * Copyright (c) Dan Phillimore (asmblah)
+ * http://uniter.github.com/phptoast/
+ *
+ * Released under the MIT license
+ * https://github.com/uniter/phptoast/raw/master/MIT-LICENSE.txt
+ */
+
+'use strict';
+
+var _ = require('microdash'),
+    expect = require('chai').expect,
+    tools = require('../../tools');
+
+describe('PHP Parser grammar clone operator integration', function () {
+    var parser;
+
+    beforeEach(function () {
+        parser = tools.createParser();
+    });
+
+    _.each({
+        'returning a clone of a variable': {
+            code: 'return clone $sourceVar;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_CLONE_EXPRESSION',
+                        operand: {
+                            name: 'N_VARIABLE',
+                            variable: 'sourceVar'
+                        }
+                    }
+                }]
+            }
+        },
+        'assigning a clone of a variable to another variable': {
+            code: '$targetVar = clone $sourceVar;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_EXPRESSION',
+                        left: {
+                            name: 'N_VARIABLE',
+                            variable: 'targetVar'
+                        },
+                        right: [{
+                            operator: '=',
+                            operand: {
+                                name: 'N_CLONE_EXPRESSION',
+                                operand: {
+                                    name: 'N_VARIABLE',
+                                    variable: 'sourceVar'
+                                }
+                            }
+                        }]
+                    }
+                }]
+            }
+        }
+    }, function (scenario, description) {
+        describe(description, function () {
+            var code = '<?php ' + scenario.code;
+
+            // Pretty-print the code strings so any non-printable characters are readable
+            describe('when the code is ' + JSON.stringify(code) + ' ?>', function () {
+                it('should return the expected AST', function () {
+                    expect(parser.parse(code)).to.deep.equal(scenario.expectedAST);
+                });
+            });
+        });
+    });
+});

--- a/test/integration/operators/logical/andTest.js
+++ b/test/integration/operators/logical/andTest.js
@@ -181,6 +181,49 @@ describe('PHP Parser grammar logical And "<value> && <value>" operator integrati
                     }
                 }]
             }
+        },
+        'precedence should be higher than a logical AND': {
+            code: '$result = $value1 && $value2 & $mask;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_EXPRESSION',
+                        left: {
+                            name: 'N_VARIABLE',
+                            variable: 'result'
+                        },
+                        right: [{
+                            operator: '=',
+                            operand: {
+                                name: 'N_EXPRESSION',
+                                left: {
+                                    name: 'N_VARIABLE',
+                                    variable: 'value1'
+                                },
+                                right: [{
+                                    operator: '&&',
+                                    operand: {
+                                        name: 'N_EXPRESSION',
+                                        left: {
+                                            name: 'N_VARIABLE',
+                                            variable: 'value2'
+                                        },
+                                        right: [{
+                                            operator: '&',
+                                            operand: {
+                                                name: 'N_VARIABLE',
+                                                variable: 'mask'
+                                            }
+                                        }]
+                                    }
+                                }]
+                            }
+                        }]
+                    }
+                }]
+            }
         }
     }, function (scenario, description) {
         describe(description, function () {

--- a/test/integration/operators/scopeResolution/constantTest.js
+++ b/test/integration/operators/scopeResolution/constantTest.js
@@ -54,6 +54,58 @@ describe('PHP Parser grammar scope resolution operator "::" constant integration
                     }
                 }]
             }
+        },
+        'reading constant from instance method call result': {
+            code: 'return $myObject->myMethod()::MY_CONST;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_CLASS_CONSTANT',
+                        className: {
+                            name: 'N_METHOD_CALL',
+                            object: {
+                                name: 'N_VARIABLE',
+                                variable: 'myObject'
+                            },
+                            calls: [{
+                                func: {
+                                    name: 'N_STRING',
+                                    string: 'myMethod'
+                                },
+                                args: []
+                            }]
+                        },
+                        constant: 'MY_CONST'
+                    }
+                }]
+            }
+        },
+        'reading constant from static method call result': {
+            code: 'return MyClass::myStaticMethod()::MY_CONST;',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_RETURN_STATEMENT',
+                    expression: {
+                        name: 'N_CLASS_CONSTANT',
+                        className: {
+                            name: 'N_STATIC_METHOD_CALL',
+                            className: {
+                                name: 'N_STRING',
+                                string: 'MyClass'
+                            },
+                            method: {
+                                name: 'N_STRING',
+                                string: 'myStaticMethod'
+                            },
+                            args: []
+                        },
+                        constant: 'MY_CONST'
+                    }
+                }]
+            }
         }
     }, function (scenario, description) {
         describe(description, function () {

--- a/test/integration/operators/scopeResolution/staticMethodTest.js
+++ b/test/integration/operators/scopeResolution/staticMethodTest.js
@@ -240,6 +240,40 @@ describe('PHP Parser grammar scope resolution operator "::" static method integr
                     }
                 }]
             }
+        },
+        'calling dynamically ({<expr>}) referenced static method with name referenced by expression': {
+            code: 'MyClass::{"my" . "StaticMethod"}(4);',
+            expectedAST: {
+                name: 'N_PROGRAM',
+                statements: [{
+                    name: 'N_EXPRESSION_STATEMENT',
+                    expression: {
+                        name: 'N_STATIC_METHOD_CALL',
+                        className: {
+                            name: 'N_STRING',
+                            string: 'MyClass'
+                        },
+                        method: {
+                            name: 'N_EXPRESSION',
+                            left: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'my'
+                            },
+                            right: [{
+                                operator: '.',
+                                operand: {
+                                    name: 'N_STRING_LITERAL',
+                                    string: 'StaticMethod'
+                                }
+                            }]
+                        },
+                        args: [{
+                            name: 'N_INTEGER',
+                            number: '4'
+                        }]
+                    }
+                }]
+            }
         }
     }, function (scenario, description) {
         describe(description, function () {

--- a/test/integration/statements/class/constantTest.js
+++ b/test/integration/statements/class/constantTest.js
@@ -37,11 +37,13 @@ EOS
                     className: 'Planet',
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'SHAPE',
-                        value: {
-                            name: 'N_STRING_LITERAL',
-                            string: 'sphere'
-                        }
+                        constants: [{
+                            constant: 'SHAPE',
+                            value: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'sphere'
+                            }
+                        }]
                     }]
                 }]
             }
@@ -61,21 +63,23 @@ EOS
                     className: 'Planet',
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'SHAPE',
-                        value: {
-                            name: 'N_EXPRESSION',
-                            left: {
-                                name: 'N_STRING_LITERAL',
-                                string: 'sphere'
-                            },
-                            right: [{
-                                operator: '.',
-                                operand: {
+                        constants: [{
+                            constant: 'SHAPE',
+                            value: {
+                                name: 'N_EXPRESSION',
+                                left: {
                                     name: 'N_STRING_LITERAL',
-                                    string: ' not circle'
-                                }
-                            }]
-                        }
+                                    string: 'sphere'
+                                },
+                                right: [{
+                                    operator: '.',
+                                    operand: {
+                                        name: 'N_STRING_LITERAL',
+                                        string: ' not circle'
+                                    }
+                                }]
+                            }
+                        }]
                     }]
                 }]
             }

--- a/test/integration/statements/class/implementsTest.js
+++ b/test/integration/statements/class/implementsTest.js
@@ -38,11 +38,13 @@ EOS
                     implement: ['Rotatable'],
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'SHAPE',
-                        value: {
-                            name: 'N_STRING_LITERAL',
-                            string: 'sphere'
-                        }
+                        constants: [{
+                            constant: 'SHAPE',
+                            value: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'sphere'
+                            }
+                        }]
                     }]
                 }]
             }
@@ -63,11 +65,13 @@ EOS
                     implement: ['Rotatable', 'Orbitable'],
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'SHAPE',
-                        value: {
-                            name: 'N_STRING_LITERAL',
-                            string: 'sphere'
-                        }
+                        constants: [{
+                            constant: 'SHAPE',
+                            value: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'sphere'
+                            }
+                        }]
                     }]
                 }]
             }

--- a/test/integration/statements/class/instanceMethodDefaultArgumentValueTest.js
+++ b/test/integration/statements/class/instanceMethodDefaultArgumentValueTest.js
@@ -119,11 +119,13 @@ EOS
                     className: 'Thing',
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'MY_CONST',
-                        value: {
-                            name: 'N_INTEGER',
-                            number: '21'
-                        }
+                        constants: [{
+                            constant: 'MY_CONST',
+                            value: {
+                                name: 'N_INTEGER',
+                                number: '21'
+                            }
+                        }]
                     }, {
                         name: 'N_METHOD_DEFINITION',
                         func: {
@@ -170,11 +172,13 @@ EOS
                     className: 'Thing',
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'MY_CONST',
-                        value: {
-                            name: 'N_INTEGER',
-                            number: '21'
-                        }
+                        constants: [{
+                            constant: 'MY_CONST',
+                            value: {
+                                name: 'N_INTEGER',
+                                number: '21'
+                            }
+                        }]
                     }, {
                         name: 'N_METHOD_DEFINITION',
                         func: {

--- a/test/integration/statements/interface/constantTest.js
+++ b/test/integration/statements/interface/constantTest.js
@@ -37,11 +37,13 @@ EOS
                     interfaceName: 'Planet',
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'SHAPE',
-                        value: {
-                            name: 'N_STRING_LITERAL',
-                            string: 'sphere'
-                        }
+                        constants: [{
+                            constant: 'SHAPE',
+                            value: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'sphere'
+                            }
+                        }]
                     }]
                 }]
             }
@@ -61,14 +63,16 @@ EOS
                     interfaceName: 'Thing',
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'FIRST',
-                        value: {
-                            name: 'N_CLASS_CONSTANT',
-                            className: {
-                                name: 'N_SELF'
-                            },
-                            constant: 'SECOND'
-                        }
+                        constants: [{
+                            constant: 'FIRST',
+                            value: {
+                                name: 'N_CLASS_CONSTANT',
+                                className: {
+                                    name: 'N_SELF'
+                                },
+                                constant: 'SECOND'
+                            }
+                        }]
                     }]
                 }]
             }

--- a/test/integration/statements/interface/extendsTest.js
+++ b/test/integration/statements/interface/extendsTest.js
@@ -66,11 +66,13 @@ EOS
                     extend: ['Rotatable', 'Orbitable'],
                     members: [{
                         name: 'N_CONSTANT_DEFINITION',
-                        constant: 'SHAPE',
-                        value: {
-                            name: 'N_STRING_LITERAL',
-                            string: 'sphere'
-                        }
+                        constants: [{
+                            constant: 'SHAPE',
+                            value: {
+                                name: 'N_STRING_LITERAL',
+                                string: 'sphere'
+                            }
+                        }]
                     }]
                 }]
             }


### PR DESCRIPTION
- Fix issue with being unable to read a class constant where class expression is a method call
- Add support for parsing dynamic references to static methods with expression for name
- Fix string interpolation with variable-variable dynamic static method call
- Allow class constant definitions to be comma-separated
- Parse PHP `clone ...` expressions as `N_CLONE_EXPRESSION` (the `clone` operator is now fully supported in Uniter)
- Fix support for heredocs & nowdocs with whitespace just before the opening identifier
- Fix issues with string literal parsing when final character is special
- Fix precedence of bitwise "&" operator vs. logical "&&"
